### PR TITLE
Fix signup form title

### DIFF
--- a/src/features/auth/signup/Signup.tsx
+++ b/src/features/auth/signup/Signup.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Redirect, Route, Switch } from "react-router-dom";
 import { signupRoute } from "../../../AppRoutes";
 import Alert from "../../../components/Alert";
-import PageTitle from "../../../components/TextField";
+import PageTitle from "../../../components/PageTitle";
 import { useTypedSelector } from "../../../store";
 import CompleteSignupForm from "./CompleteSignupForm";
 import EmailForm from "./EmailForm";

--- a/src/features/profile/ProfileTextInput.tsx
+++ b/src/features/profile/ProfileTextInput.tsx
@@ -1,6 +1,6 @@
 import { TextFieldProps } from "@material-ui/core";
 import React from "react";
-import TextInput from "../../components/TextField";
+import TextField from "../../components/TextField";
 
 interface ProfileTextInputProps
   extends Pick<
@@ -9,5 +9,5 @@ interface ProfileTextInputProps
   > {}
 
 export default function ProfileTextInput(props: ProfileTextInputProps) {
-  return <TextInput {...props} variant="outlined" margin="normal" fullWidth />;
+  return <TextField {...props} variant="outlined" margin="normal" fullWidth />;
 }

--- a/src/features/profile/UserInfoForm.tsx
+++ b/src/features/profile/UserInfoForm.tsx
@@ -5,7 +5,7 @@ import React, { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import Alert from "../../components/Alert";
 import Button from "../../components/Button";
-import TextInput from "../../components/TextField";
+import TextField from "../../components/TextField";
 import ProfileTextInput from "./ProfileTextInput";
 import { ProfileFormData, updateUserProfile } from "./index";
 import { useAppDispatch, useTypedSelector } from "../../store";
@@ -83,7 +83,7 @@ export default function UserInfoForm() {
                 open={false}
                 options={[""]}
                 renderInput={(params) => (
-                  <TextInput
+                  <TextField
                     {...params}
                     helperText="Press 'Enter' to add"
                     label="Languages"
@@ -122,7 +122,7 @@ export default function UserInfoForm() {
                 open={false}
                 options={[""]}
                 renderInput={(params) => (
-                  <TextInput
+                  <TextField
                     {...params}
                     helperText="Press 'Enter' to add"
                     label="Countries I visited"
@@ -145,7 +145,7 @@ export default function UserInfoForm() {
                 open={false}
                 options={[""]}
                 renderInput={(params) => (
-                  <TextInput
+                  <TextField
                     {...params}
                     helperText="Press 'Enter' to add"
                     label="Countries I lived in"


### PR DESCRIPTION
Lol not sure how that slipped through the crack!

Fixed the import of PageTitle on sign up form to actually import the `PageTitle` component rather than `TextField`! Also tidied up a few missed renames of `TextInput` to `TextField` in the cleanup PR.