### PR TITLE
Allow API base URL to be defined in env var

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+REACT_APP_API_BASE_URL=http://localhost:8888

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,3 +1,9 @@
 /// <reference types="react-scripts" />
 /// <reference types="react-dom/experimental" />
 /// <reference types="react/experimental" />
+declare namespace NodeJS {
+  interface ProcessEnv {
+    NODE_ENV: "development" | "production" | "test";
+    REACT_APP_API_BASE_URL: string;
+  }
+}

--- a/src/service/api.ts
+++ b/src/service/api.ts
@@ -7,7 +7,7 @@ import { SSOPromiseClient } from "../pb/sso_grpc_web_pb";
 
 import { store } from "../store";
 
-const URL = process.env.REACT_APP_API_BASE_URL || "http://localhost:8888";
+const URL = process.env.REACT_APP_API_BASE_URL as string;
 
 class AuthInterceptor {
   intercept(request: any, invoker: (request: any) => any) {

--- a/src/service/api.ts
+++ b/src/service/api.ts
@@ -7,7 +7,7 @@ import { SSOPromiseClient } from "../pb/sso_grpc_web_pb";
 
 import { store } from "../store";
 
-const URL = "http://localhost:8888";
+const URL = process.env.REACT_APP_API_BASE_URL || "http://localhost:8888";
 
 class AuthInterceptor {
   intercept(request: any, invoker: (request: any) => any) {

--- a/src/service/api.ts
+++ b/src/service/api.ts
@@ -7,7 +7,7 @@ import { SSOPromiseClient } from "../pb/sso_grpc_web_pb";
 
 import { store } from "../store";
 
-const URL = process.env.REACT_APP_API_BASE_URL as string;
+const URL = process.env.REACT_APP_API_BASE_URL;
 
 class AuthInterceptor {
   intercept(request: any, invoker: (request: any) => any) {


### PR DESCRIPTION
This allows running against the prod backend with

```sh
REACT_APP_API_BASE_URL="https://api.couchers.org" yarn start
```

Feel free to merge if approved.